### PR TITLE
feat(action): Support excluded sources and allowed words for profanity filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ The following table describes each input:
 | `include-confused-reaction` | A `boolean` value to indicate if the action should react to the issue or pull request with the confused 😕 reaction. | `false` (default: `false`) |
 | `manual-profane-words` | A `string` value, with a comma-separated list of additional profane words to include in the filter. | `false` |
 | `custom-profane-words-url` | A URL that returns a `string` value, with a newline-separated list of custom profane words to include in the filter. | `false` |
+| `exclude-profane-sources` | A `string` value, with a comma-separated list of dictionary source names to exclude, for example `GoogleBannedWords` or `GoogleBannedWords.txt`. | `false` |
+| `exclude-profane-words` | A `string` value, with a comma-separated list of words to whitelist and exclude from filtering, for example `mongo`. | `false` |
+
+### 🧪 Exclusion examples
+
+To exclude entire dictionaries and whitelist specific words, configure the action like this:
+
+```yml
+- name: Scan issue or pull request for profanity
+  if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
+  uses: IEvangelist/profanity-filter@main
+  id: profanity-filter
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+    replacement-strategy: middle-asterisk
+    # Skip one or more dictionaries by source name.
+    exclude-profane-sources: GoogleBannedWords,ItalianSwearWords
+    # Keep these words unchanged even if present in any dictionary.
+    exclude-profane-words: mongo,redis,kubernetes
+```
+
+Notes:
+
+- `exclude-profane-sources` accepts source names with or without `.txt` extension.
+- `exclude-profane-words` is case-insensitive.
+- Both inputs support comma-separated values.
 
 ### 😵 Replacement strategies
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ Notes:
 - `exclude-profane-words` is case-insensitive.
 - Both inputs support comma-separated values.
 
+### 📚 Built-in dictionary sources
+
+The following built-in source names can be used with `exclude-profane-sources`:
+
+- `GoogleBannedWords`
+- `SwedishSwearWords`
+- `IndonesianSwearWords`
+- `RussianSwearWords`
+- `GermanSwearWords`
+- `ItalianSwearWords`
+
+For the complete list, see [src/ProfanityFilter.Services/Data](src/ProfanityFilter.Services/Data).
+
 ### 😵 Replacement strategies
 
 Each replacement strategy corresponds to a different way of replacing profane content. The following represents the available replacement types:

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description:
       'A URL that returns a newline-delimted list of custom words to use for profanity filtering.'
     required: false
+  exclude-profane-sources:
+    description:
+      'A comma-separated list of source dictionaries to exclude, for example GoogleBannedWords or GoogleBannedWords.txt.'
+    required: false
+  exclude-profane-words:
+    description:
+      'A comma-separated list of words to whitelist and exclude from profanity filtering, for example mongo.'
+    required: false
 
 runs:
   using: 'docker'

--- a/src/ProfanityFilter.Action/Extensions/CoreServiceExtensions.cs
+++ b/src/ProfanityFilter.Action/Extensions/CoreServiceExtensions.cs
@@ -97,6 +97,18 @@ internal static class CoreServiceExtensions
     private static readonly string[] s_newLines = ["\r\n", "\r", "\n"];
 
     /// <summary>
+    /// Gets source names to exclude from the action's input <c>exclude-profane-sources</c> value.
+    /// </summary>
+    public static string[]? GetExcludedProfaneSources(this ICoreService core) =>
+        ParseDelimitedInput(core.GetInput(ActionInputs.ExcludeProfaneSources));
+
+    /// <summary>
+    /// Gets words to exclude from the action's input <c>exclude-profane-words</c> value.
+    /// </summary>
+    public static string[]? GetExcludedProfaneWords(this ICoreService core) =>
+        ParseDelimitedInput(core.GetInput(ActionInputs.ExcludeProfaneWords));
+
+    /// <summary>
     /// Gets the custom profane words from the action's input <c>custom-profane-words-url</c> value,
     /// making an HTTP GET call to the specified URL.
     /// </summary>
@@ -124,5 +136,15 @@ internal static class CoreServiceExtensions
         }
 
         return default;
+    }
+
+    private static string[]? ParseDelimitedInput(string? input)
+    {
+        return input is null or { Length: 0 }
+            ? (string[]?)default
+            : input.Split([',', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+                .Select(static value => value.Trim())
+                .Where(static value => value.Length > 0)
+                .ToArray();
     }
 }

--- a/src/ProfanityFilter.Action/Models/ActionInputs.cs
+++ b/src/ProfanityFilter.Action/Models/ActionInputs.cs
@@ -30,4 +30,14 @@ internal static class ActionInputs
     /// The name of the <i>action.yml</i> input: <c>"custom-profane-words-url"</c>.
     /// </summary>
     internal const string CustomProfaneWordsUrl = "custom-profane-words-url";
+
+    /// <summary>
+    /// The name of the <i>action.yml</i> input: <c>"exclude-profane-sources"</c>.
+    /// </summary>
+    internal const string ExcludeProfaneSources = "exclude-profane-sources";
+
+    /// <summary>
+    /// The name of the <i>action.yml</i> input: <c>"exclude-profane-words"</c>.
+    /// </summary>
+    internal const string ExcludeProfaneWords = "exclude-profane-words";
 }

--- a/src/ProfanityFilter.Action/ProfanityProcessor.IssueComment.cs
+++ b/src/ProfanityFilter.Action/ProfanityProcessor.IssueComment.cs
@@ -28,11 +28,15 @@ internal sealed partial class ProfanityProcessor
             var replacementStrategy = core.GetReplacementStrategy();
 
             var additionalFilters = await GetAdditionalFiltersAsync();
+            var excludedSources = core.GetExcludedProfaneSources()?.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var excludedWords = core.GetExcludedProfaneWords()?.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
             var bodyFilterResult = await TryApplyFilterAsync(
                 issueComment.Body ?? "", new(replacementStrategy, FilterTarget.Comment)
                 {
-                    AdditionalFilterSources = additionalFilters
+                    AdditionalFilterSources = additionalFilters,
+                    ExcludedFilterSources = excludedSources,
+                    ExcludedWords = excludedWords
                 });
 
             filterResult = new FiltrationResult(BodyResult: bodyFilterResult);

--- a/src/ProfanityFilter.Action/ProfanityProcessor.cs
+++ b/src/ProfanityFilter.Action/ProfanityProcessor.cs
@@ -192,17 +192,23 @@ internal sealed partial class ProfanityProcessor(
         }
 
         var additionalFilters = await GetAdditionalFiltersAsync();
+        var excludedSources = core.GetExcludedProfaneSources()?.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var excludedWords = core.GetExcludedProfaneWords()?.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var titleResult = await TryApplyFilterAsync(
             title, parameters: new(replacementStrategy, FilterTarget.Title)
             {
-                AdditionalFilterSources = additionalFilters
+                AdditionalFilterSources = additionalFilters,
+                ExcludedFilterSources = excludedSources,
+                ExcludedWords = excludedWords
             });
 
         var bodyResult = await TryApplyFilterAsync(
             body, parameters: new(replacementStrategy, FilterTarget.Body)
             {
-                AdditionalFilterSources = additionalFilters
+                AdditionalFilterSources = additionalFilters,
+                ExcludedFilterSources = excludedSources,
+                ExcludedWords = excludedWords
             });
 
         return new FiltrationResult(titleResult, bodyResult);

--- a/src/ProfanityFilter.Common/FilterParameters.cs
+++ b/src/ProfanityFilter.Common/FilterParameters.cs
@@ -21,4 +21,15 @@ public readonly record struct FilterParameters(
     /// A collection of additional profane words to consider as a filter source.
     /// </summary>
     public HashSet<ProfaneSourceFilter>? AdditionalFilterSources { get; init; }
+
+    /// <summary>
+    /// A collection of source names to exclude from filtering.
+    /// Source name values can be either full file names or source aliases.
+    /// </summary>
+    public HashSet<string>? ExcludedFilterSources { get; init; }
+
+    /// <summary>
+    /// A collection of words to exclude from filtering, acting as a whitelist.
+    /// </summary>
+    public HashSet<string>? ExcludedWords { get; init; }
 }

--- a/src/ProfanityFilter.Services/DefaultProfaneContentFilterService.cs
+++ b/src/ProfanityFilter.Services/DefaultProfaneContentFilterService.cs
@@ -88,6 +88,48 @@ internal sealed partial class DefaultProfaneContentFilterService(
             wordList[profaneSourceFilter.SourceName] = profaneSourceFilter;
         }
 
+        if (parameters.ExcludedFilterSources is { Count: > 0 } excludedSources)
+        {
+            var normalizedExcludedSources = excludedSources
+                .Where(static source => string.IsNullOrWhiteSpace(source) is false)
+                .Select(static source => NormalizeSourceName(source))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var source in wordList.Keys.ToArray())
+            {
+                if (normalizedExcludedSources.Contains(NormalizeSourceName(source)))
+                {
+                    wordList.Remove(source);
+                }
+            }
+        }
+
+        if (parameters.ExcludedWords is { Count: > 0 } excludedWords)
+        {
+            var normalizedExcludedWords = excludedWords
+                .Where(static word => string.IsNullOrWhiteSpace(word) is false)
+                .Select(static word => word.Trim())
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (source, filter) in wordList.ToArray())
+            {
+                var filteredWords = filter.ProfaneWords
+                    .Where(word => ShouldIncludeWord(word, normalizedExcludedWords))
+                    .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+                if (filteredWords.Count is 0)
+                {
+                    wordList.Remove(source);
+                    continue;
+                }
+
+                if (filteredWords.Count != filter.ProfaneWords.Count)
+                {
+                    wordList[source] = new ProfaneSourceFilter(source, filteredWords);
+                }
+            }
+        }
+
         var getEvaluator = strategy.GetMatchEvaluator();
         var evaluator = getEvaluator(parameters);
 
@@ -125,5 +167,29 @@ internal sealed partial class DefaultProfaneContentFilterService(
         {
             Matches = MatchRegistry.Unregister(parameters)
         };
+
+        static string NormalizeSourceName(string source)
+        {
+            var fileName = Path.GetFileName(source);
+            var withoutExtension = Path.GetFileNameWithoutExtension(fileName);
+
+            return string.IsNullOrWhiteSpace(withoutExtension)
+                ? source.Trim()
+                : withoutExtension.Trim();
+        }
+
+        static bool ShouldIncludeWord(string word, HashSet<string> excludedWords)
+        {
+            var trimmedWord = word.Trim();
+
+            if (excludedWords.Contains(trimmedWord))
+            {
+                return false;
+            }
+
+            var unescapedWord = Regex.Unescape(trimmedWord);
+
+            return excludedWords.Contains(unescapedWord) is false;
+        }
     }
 }

--- a/src/ProfanityFilter.Services/DefaultProfaneContentFilterService.cs
+++ b/src/ProfanityFilter.Services/DefaultProfaneContentFilterService.cs
@@ -80,8 +80,8 @@ internal sealed partial class DefaultProfaneContentFilterService(
             return result;
         }
 
-        var wordList =
-            await ReadAllProfaneWordsAsync(cancellationToken).ConfigureAwait(false);
+        var wordList = new Dictionary<string, ProfaneSourceFilter>(
+            await ReadAllProfaneWordsAsync(cancellationToken).ConfigureAwait(false));
 
         foreach (var profaneSourceFilter in parameters.AdditionalFilterSources ?? [])
         {

--- a/tests/ProfanityFilter.Services.Tests/DefaultProfaneContentFilterServiceTests.cs
+++ b/tests/ProfanityFilter.Services.Tests/DefaultProfaneContentFilterServiceTests.cs
@@ -228,4 +228,47 @@ public class DefaultProfaneContentFilterServiceTests
         CollectionAssert.That.Contains(result.Steps,
             static step => step.ProfaneSourceData.EndsWith("CustomWords.txt", StringComparison.OrdinalIgnoreCase));
     }
+
+    [TestMethod]
+    public async Task FilterProfanityAsyncWithExcludedSourcesSkipsMatchingDictionary()
+    {
+        var input = "Lots of fucking words like manky and arrusa!";
+
+        // Act
+        var result = await _sut.FilterProfanityAsync(input,
+            new(ReplacementStrategy.MiddleAsterisk, FilterTarget.Body)
+            {
+                ExcludedFilterSources = ["GoogleBannedWords"]
+            }, CancellationToken.None);
+
+        // Assert
+        Assert.IsTrue(result.IsFiltered);
+        Assert.IsNotNull(result.FinalOutput);
+        Assert.IsTrue(result.FinalOutput.Contains("fucking", StringComparison.OrdinalIgnoreCase));
+
+        Assert.IsFalse(result.Steps.Any(static step =>
+            step.IsFiltered &&
+            step.ProfaneSourceData.EndsWith("GoogleBannedWords.txt", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [TestMethod]
+    public async Task FilterProfanityAsyncWithExcludedWordsSkipsSpecificWord()
+    {
+        var input = "I love WebForms!";
+
+        // Act
+        var result = await _sut.FilterProfanityAsync(input,
+            new(ReplacementStrategy.Bleep, FilterTarget.Body)
+            {
+                AdditionalFilterSources =
+                [
+                    new("Custom", s_webFormsArray.ToFrozenSet())
+                ],
+                ExcludedWords = ["WebForms"]
+            }, CancellationToken.None);
+
+        // Assert
+        Assert.IsFalse(result.IsFiltered);
+        Assert.AreEqual(input, result.FinalOutput ?? result.Input);
+    }
 }


### PR DESCRIPTION
## Summary

Adds support to reduce false positives by allowing users to:
- exclude specific built-in profanity dictionaries
- allowlist specific words (case-insensitive)

Closes #161.

## Changes

- Added new action inputs:
  - `exclude-profane-sources`
  - `exclude-profane-words`
- Wired new inputs through Action processing into filter parameters.
- Added new filter parameters for exclusions.
- Updated filtering logic to:
  - skip excluded sources
  - skip excluded words
- Prevented shared cache mutation by copying cached dictionary to a per-request local dictionary before applying modifications.
- Added tests for source exclusion and word exclusion behavior.

## Documentation

- Added new inputs and descriptions in `action.yml`.
- Updated Inputs table in `README.md` with `exclude-profane-sources` and `exclude-profane-words`.
- Added exclusion usage examples in `README.md`.
- Added built-in source examples and a link to the full source list in `README.md` (`src/ProfanityFilter.Services/Data`).

## Validation

- Services project builds successfully.
- Exclusion behavior tests are included and passing in local run.
- One pre-existing historical test may fail in local Windows environment:
  - `FilterProfanityAsyncWithCustomDataReturnsMultiStepResult`
  - This appears unrelated to this feature.
  
  @IEvangelist 